### PR TITLE
common: add --dir/-d option to RUNTESTS.py

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -44,7 +44,7 @@ foreach file : manpages_md
     if get_option('web')
         dest_windows = meson.current_build_dir()/'web_windows'/dir/name
         dest_linux = meson.current_build_dir()/'web_linux'/dir/name
-        # It is not platform independent but docs can only be build on linux
+        # It is not platform independent but docs can only be built on linux
         run_command('mkdir', '-p', meson.current_build_dir()/'web_windows'/dir, check:true)
         run_command('mkdir', '-p', meson.current_build_dir()/'web_linux'/dir, check:true)
 

--- a/src/test/RUNTESTS.py
+++ b/src/test/RUNTESTS.py
@@ -151,9 +151,9 @@ class TestRunner:
                        .format(tc, futils.Color.GREEN, futils.Color.END, tm))
 
 
-def _import_testfiles():
+def _import_testfiles(dir):
     """
-    Traverse through "src/test" directory, find all "TESTS.py" files and
+    Traverse through "config.dir" directory, find all "TESTS.py" files and
     import them as modules. Set imported module name to
     file directory path.
 
@@ -165,7 +165,7 @@ def _import_testfiles():
           therefore available through basetest.get_testfiles() function
 
     """
-    for root, _, files in os.walk(ROOTDIR):
+    for root, _, files in os.walk(path.join(os.path.dirname(__file__), dir)):
         for name in files:
             if name == 'TESTS.py':
                 testfile = path.join(root, name)
@@ -177,8 +177,8 @@ def _import_testfiles():
 
 
 def main():
-    _import_testfiles()
     config = Configurator().config
+    _import_testfiles(config.dir)
     testcases = get_testcases()
 
     if config.group:

--- a/src/test/testconfig.py.example
+++ b/src/test/testconfig.py.example
@@ -9,6 +9,13 @@ config = {
     # The first part of the file tells the test framework
     # which file system locations are to be used for local testing.
     #
+
+    #
+    # Set tests directory relative to the RUNTESTS.py script
+    #
+
+    'dir': '../../build/src/test',
+
     #
     # Set logging level. Possible values:
     # 0 - silent (only error messages)

--- a/src/test/unittest/configurator.py
+++ b/src/test/unittest/configurator.py
@@ -239,6 +239,9 @@ class Configurator():
             return [str(c) for c in cls.__subclasses__()]
 
         parser = argparse.ArgumentParser()
+        parser.add_argument('-d', '--dir', dest='dir',
+                            help='set tests directory relative'
+                            'to RUNTESTS.py script')
         parser.add_argument('--fs_dir_force_pmem', type=int,
                             help='set PMEM_IS_PMEM_FORCE for tests run on'
                             ' pmem fs')


### PR DESCRIPTION
Ten katalog ustawiam na podstawie testconfigu lub --dir/-d. Uznałem, że najlepiej jest podawać ścieżkę do katalogu z testami względem RUNTESTS.py, co o tym sądzisz?