### PR TITLE
Add (-)-dir option to RUNTESTS scripts

### DIFF
--- a/src/test/RUNTESTLIB.PS1
+++ b/src/test/RUNTESTLIB.PS1
@@ -116,11 +116,11 @@ class Config {
     #
     # setTestdir -- parse test directory
     #
-    setTestdir($testdir) {
+    setTestdir($tests_root_dir, $testdir) {
         if ($testdir -eq "all") {
-            $this.testdir = Get-ChildItem -Directory
+            $this.testdir = Get-ChildItem -Directory $tests_root_dir
         } else {
-            $this.testdir = Get-Item $testdir
+            $this.testdir = Get-Item $testdir # TODO: It is not using tests_root_dir, we may change that
         }
     }
 }

--- a/src/test/RUNTESTS
+++ b/src/test/RUNTESTS
@@ -437,6 +437,7 @@ testconfig="./testconfig.sh"
 killopt="-k 10s"
 runtest_timeout="3m"
 use_timeout="ok"
+testsdir="."
 testfile=all
 testseq=all
 check_pool=0
@@ -512,9 +513,9 @@ fi
 #
 # command-line argument processing...
 #
-args=`getopt k:nvb:t:f:o:s:u:m:e:p:d:cq:r:g:x: $*`
+args=`getopt -o k:nvb:t:f:o:s:u:m:e:p:d:cq:r:g:x: -l dir: -- $*`
 [ $? != 0 ] && usage
-set -- $args
+eval set -- "$args"
 for arg
 do
 	receivetype=auto
@@ -695,6 +696,10 @@ do
 			;;
 		esac
 		;;
+  --dir)
+    testsdir="$2"
+    shift 2
+    ;;
 	--)
 		shift
 		break
@@ -773,7 +778,7 @@ if [ "$1" ]; then
 	done
 else
 	# no arguments means run them all
-	for testfile0 in */TEST0
+	for testfile0 in "$(realpath $testsdir)/*/TEST0"
 	do
 		testdir=`dirname $testfile0`
 		if [[ "$skip_dir" =~ "$testdir" ]]; then

--- a/src/test/RUNTESTS.PS1
+++ b/src/test/RUNTESTS.PS1
@@ -90,7 +90,10 @@ Param(
     [uint32]$jobs = 1,
 
     [alias("h")]
-    [switch]$help= $false
+    [switch]$help= $false,
+
+    [alias("dir")]
+    [string]$tests_root_dir= '.\'
 )
 
 if ($PSVersionTable.PSVersion.Major -lt 5) {
@@ -114,7 +117,7 @@ $config = New-Object Config
 $config.setBuildtype($buildtype)
 $config.setFstype($fstype)
 $config.setTimeout($time)
-$config.setTestdir($testdir)
+$config.setTestdir($tests_root_dir, $testdir)
 $config.testtype = $testtype
 $config.check_pool = $check_pool
 $config.skip_dir = $skip_dir


### PR DESCRIPTION
Chciałem zrobić w powershellu też `--dir`, ale chyba nie ma takiej możliwości, więc jest `--dir` na uniksie i `-dir` na windowsie