### PR TITLE
test: include pmem2 dir in map test

### DIFF
--- a/src/test/pmem2_map/meson.build
+++ b/src/test/pmem2_map/meson.build
@@ -9,7 +9,9 @@ dependencies = [
 ]
 
 c_args = []
+
 include_directories = [
+    include_directories('../../libpmem2'),
     miniasync_include,
 ]
 


### PR DESCRIPTION
pmem2_map.c includes config.h header from valgrind system headers
when libpmem2 dir is not in the include_directories list.
libpmem2 dir also has to be declared before miniasync_include.