### PR TITLE
common: add license checker to meson

### DIFF
--- a/doc/daxio/meson.build
+++ b/doc/daxio/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 manpages_1_md += files(
         'daxio.1.md',
         )

--- a/doc/generated/meson.build
+++ b/doc/generated/meson.build
@@ -1,1 +1,4 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 r = run_command('../../utils/get_aliases.sh', check: true)

--- a/doc/libpmem/meson.build
+++ b/doc/libpmem/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 manpages_7_md += files(
     'libpmem.7.md',
     )

--- a/doc/libpmem2/meson.build
+++ b/doc/libpmem2/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 manpages_7_md += files(
     'libpmem2.7.md',
     'libpmem2_unsafe_shutdown.7.md',

--- a/doc/libpmemblk/meson.build
+++ b/doc/libpmemblk/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 manpages_7_md += files(
     'libpmemblk.7.md',
     )

--- a/doc/libpmemlog/meson.build
+++ b/doc/libpmemlog/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 manpages_7_md += files(
     'libpmemlog.7.md',
     )

--- a/doc/libpmemobj/meson.build
+++ b/doc/libpmemobj/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 manpages_7_md += files(
     'libpmemobj.7.md',
     )

--- a/doc/libpmempool/meson.build
+++ b/doc/libpmempool/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 manpages_7_md += files(
     'libpmempool.7.md',
     )

--- a/doc/libpmemset/meson.build
+++ b/doc/libpmemset/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 manpages_7_md += files(
     'libpmemset.7.md',
     )

--- a/doc/librpmem/meson.build
+++ b/doc/librpmem/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 manpages_7_md += files(
     'librpmem.7.md',
     )

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 manpages_7_md = files()
 manpages_5_md = files()
 manpages_3_md = files()

--- a/doc/pmem_ctl/meson.build
+++ b/doc/pmem_ctl/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 manpages_7_md += files(
     )
 

--- a/doc/pmempool/meson.build
+++ b/doc/pmempool/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 manpages_7_md += files(
     )
 

--- a/doc/pmreorder/meson.build
+++ b/doc/pmreorder/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 manpages_7_md += files(
     )
 

--- a/doc/poolset/meson.build
+++ b/doc/poolset/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 manpages_7_md += files(
     )
 

--- a/doc/rpmemd/meson.build
+++ b/doc/rpmemd/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 manpages_7_md += files(
     )
 

--- a/meson.build
+++ b/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 project(
     'pmdk',
     ['c'],
@@ -82,6 +85,10 @@ endif
 cstyle_files = run_command('utils/get-cstyle-files.py', meson.project_source_root(),
                             meson.project_build_root()).stdout().strip().split('\n')
 
-# add cstyle utility- to compile use meson compile cstyle_pmdk (move this info to README later)
-run_target('cstyle_pmdk',
+# add cstyle utility- to compile use meson compile cstyle-pmdk (move this info to README later)
+run_target('cstyle-pmdk',
             command : ['utils/cstyle', cstyle_files])
+
+# add check-license utility- to compile use meson compile check-license (move this info to README later)
+run_target('check-license',
+            command : ['utils/check_license/check-headers.sh', meson.project_source_root(), 'BSD-3-Clause'])

--- a/src/common/meson.build
+++ b/src/common/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'bad_blocks.c',
     'set_badblocks.c',

--- a/src/core/meson.build
+++ b/src/core/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'alloc.c',
     'fs_posix.c',

--- a/src/examples/libpmem/meson.build
+++ b/src/examples/libpmem/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 executable(
     'full_copy',
     'full_copy.c',

--- a/src/examples/libpmem2/advanced/meson.build
+++ b/src/examples/libpmem2/advanced/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 executable(
     'advanced',
     'advanced.c',

--- a/src/examples/libpmem2/basic/meson.build
+++ b/src/examples/libpmem2/basic/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 executable(
     'basic',
     'basic.c',

--- a/src/examples/libpmem2/log/meson.build
+++ b/src/examples/libpmem2/log/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 executable(
     'log',
     'log.c',

--- a/src/examples/libpmem2/map_multiple_files/meson.build
+++ b/src/examples/libpmem2/map_multiple_files/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 executable(
     'map_multiple_files',
     'map_multiple_files.c',

--- a/src/examples/libpmem2/meson.build
+++ b/src/examples/libpmem2/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 subdir('advanced')
 subdir('basic')
 subdir('log')

--- a/src/examples/libpmem2/redo/meson.build
+++ b/src/examples/libpmem2/redo/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 executable(
     'redo',
     'redo.c',

--- a/src/examples/libpmem2/ringbuf/meson.build
+++ b/src/examples/libpmem2/ringbuf/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 executable(
     'ringbuf',
     'ringbuf.c',

--- a/src/examples/libpmem2/unsafe_shutdown/meson.build
+++ b/src/examples/libpmem2/unsafe_shutdown/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 executable(
     'unsafe_shutdown',
     'unsafe_shutdown.c',

--- a/src/examples/libpmemblk/assetdb/meson.build
+++ b/src/examples/libpmemblk/assetdb/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 include_directories = [
     include_directories('../../'),
     include_directories('.'),

--- a/src/examples/libpmemblk/meson.build
+++ b/src/examples/libpmemblk/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 executable(
     'manpage',
     'manpage.c',

--- a/src/examples/libpmemlog/logfile/meson.build
+++ b/src/examples/libpmemlog/logfile/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 include_directories = [
     include_directories('../../'),
     include_directories('.'),

--- a/src/examples/libpmemlog/meson.build
+++ b/src/examples/libpmemlog/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 executable(
     'manpage',
     'manpage.c',

--- a/src/examples/libpmemobj/hashmap/meson.build
+++ b/src/examples/libpmemobj/hashmap/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 libhashmap_atomic = static_library(
     'hashmap_atomic',
     'hashmap_atomic.c',

--- a/src/examples/libpmemobj/libart/meson.build
+++ b/src/examples/libpmemobj/libart/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 libart = library(
     'art',
     'art.c',

--- a/src/examples/libpmemobj/linkedlist/meson.build
+++ b/src/examples/libpmemobj/linkedlist/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 executable(
     'fifo',
     'fifo.c',

--- a/src/examples/libpmemobj/list_map/meson.build
+++ b/src/examples/libpmemobj/list_map/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 libskiplist_map = static_library(
     'skiplist_map',
     'skiplist_map.c',

--- a/src/examples/libpmemobj/map/meson.build
+++ b/src/examples/libpmemobj/map/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 libmap_ctree = library(
     'map_ctree',
     files('map_ctree.c', 'map.c'),

--- a/src/examples/libpmemobj/meson.build
+++ b/src/examples/libpmemobj/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 include_directories = [
     include_directories('../'),
     include_directories('.'),

--- a/src/examples/libpmemobj/pmemblk/meson.build
+++ b/src/examples/libpmemobj/pmemblk/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 executable(
     'obj_pmemblk',
     'obj_pmemblk.c',

--- a/src/examples/libpmemobj/pmemlog/meson.build
+++ b/src/examples/libpmemobj/pmemlog/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 executable(
     'obj_pmemlog',
     'obj_pmemlog.c',

--- a/src/examples/libpmemobj/pmemobjfs/meson.build
+++ b/src/examples/libpmemobj/pmemobjfs/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 FUSE_REQ_VER = '2.9.1'
 
 if libfuse_dep.found()

--- a/src/examples/libpmemobj/pminvaders/meson.build
+++ b/src/examples/libpmemobj/pminvaders/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 if libncurses_dep.found()
     executable(
         'pminvaders',

--- a/src/examples/libpmemobj/queue/meson.build
+++ b/src/examples/libpmemobj/queue/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 executable(
     'queue',
     'queue.c',

--- a/src/examples/libpmemobj/slab_allocator/meson.build
+++ b/src/examples/libpmemobj/slab_allocator/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 libslab_allocator = library(
     'slab_allocator',
     'slab_allocator.c',

--- a/src/examples/libpmemobj/string_store/meson.build
+++ b/src/examples/libpmemobj/string_store/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 executable(
     'writer',
     'writer.c',

--- a/src/examples/libpmemobj/string_store_tx/meson.build
+++ b/src/examples/libpmemobj/string_store_tx/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 executable(
     'writer',
     'writer.c',

--- a/src/examples/libpmemobj/string_store_tx_type/meson.build
+++ b/src/examples/libpmemobj/string_store_tx_type/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 executable(
     'writer',
     'writer.c',

--- a/src/examples/libpmemobj/tree_map/meson.build
+++ b/src/examples/libpmemobj/tree_map/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 libctree_map = static_library(
     'ctree_map',
     'ctree_map.c',

--- a/src/examples/libpmempool/meson.build
+++ b/src/examples/libpmempool/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 executable(
     'manpage',
     'manpage.c',

--- a/src/examples/libpmemset/basic/meson.build
+++ b/src/examples/libpmemset/basic/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 executable(
     'basic',
     'basic.c',

--- a/src/examples/libpmemset/meson.build
+++ b/src/examples/libpmemset/meson.build
@@ -1,1 +1,4 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 subdir('basic')

--- a/src/examples/meson.build
+++ b/src/examples/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 examples_include = include_directories('.')
 
 subdir('libpmem')

--- a/src/examples/pmreorder/meson.build
+++ b/src/examples/pmreorder/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 executable(
     'pmreorder_list',
     'pmreorder_list.c',

--- a/src/libpmem/meson.build
+++ b/src/libpmem/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'libpmem.c',
     '../libpmem2/memops_generic.c',

--- a/src/libpmem2/meson.build
+++ b/src/libpmem2/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files()
 compile_args = []
 includes = [include_directories('.')]

--- a/src/libpmemblk/meson.build
+++ b/src/libpmemblk/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'blk.c',
     'btt.c',

--- a/src/libpmemlog/meson.build
+++ b/src/libpmemlog/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'libpmemlog.c',
     'log.c'

--- a/src/libpmemobj/meson.build
+++ b/src/libpmemobj/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'alloc_class.c',
     'bucket.c',

--- a/src/libpmempool/meson.build
+++ b/src/libpmempool/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'libpmempool.c',
     'check.c',

--- a/src/libpmemset/meson.build
+++ b/src/libpmemset/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'badblock.c',
     'config.c',

--- a/src/librpmem/meson.build
+++ b/src/librpmem/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     '../core/alloc.c',
     '../core/os_posix.c',

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 root_include = include_directories('include')
 common_include = include_directories('common')
 core_include = include_directories('core')

--- a/src/test/arch_flags/meson.build
+++ b/src/test/arch_flags/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'arch_flags.c',
 )

--- a/src/test/blk_include/meson.build
+++ b/src/test/blk_include/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'blk_include.c',
 )

--- a/src/test/blk_nblock/meson.build
+++ b/src/test/blk_nblock/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'blk_nblock.c',
 )

--- a/src/test/blk_non_zero/meson.build
+++ b/src/test/blk_non_zero/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'blk_non_zero.c',
 )

--- a/src/test/blk_pool/meson.build
+++ b/src/test/blk_pool/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'blk_pool.c',
 )

--- a/src/test/blk_pool_lock/meson.build
+++ b/src/test/blk_pool_lock/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'blk_pool_lock.c',
 )

--- a/src/test/blk_pool_win/meson.build
+++ b/src/test/blk_pool_win/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'blk_pool_win.c',
 )

--- a/src/test/blk_recovery/meson.build
+++ b/src/test/blk_recovery/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'blk_recovery.c',
 )

--- a/src/test/blk_rw/meson.build
+++ b/src/test/blk_rw/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'blk_rw.c',
 )

--- a/src/test/blk_rw_mt/meson.build
+++ b/src/test/blk_rw_mt/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'blk_rw_mt.c',
 )

--- a/src/test/bttdevice/meson.build
+++ b/src/test/bttdevice/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/checksum/meson.build
+++ b/src/test/checksum/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'checksum.c',
 )

--- a/src/test/compat_incompat_features/meson.build
+++ b/src/test/compat_incompat_features/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pool_open.c',
 )

--- a/src/test/ctl_cow/meson.build
+++ b/src/test/ctl_cow/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'ctl_cow.c',
 )

--- a/src/test/ctl_prefault/meson.build
+++ b/src/test/ctl_prefault/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'ctl_prefault.c',
 )

--- a/src/test/daxio/meson.build
+++ b/src/test/daxio/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/ex_libpmem/meson.build
+++ b/src/test/ex_libpmem/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/ex_libpmem2/meson.build
+++ b/src/test/ex_libpmem2/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/ex_libpmemblk/meson.build
+++ b/src/test/ex_libpmemblk/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/ex_libpmemlog/meson.build
+++ b/src/test/ex_libpmemlog/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/ex_libpmemobj/meson.build
+++ b/src/test/ex_libpmemobj/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/ex_libpmemset/meson.build
+++ b/src/test/ex_libpmemset/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/ex_linkedlist/meson.build
+++ b/src/test/ex_linkedlist/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'ex_linkedlist.c',
 )

--- a/src/test/ex_pmreorder/meson.build
+++ b/src/test/ex_pmreorder/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/getopt/meson.build
+++ b/src/test/getopt/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'getopt.c',
 )

--- a/src/test/libpmempool_api/meson.build
+++ b/src/test/libpmempool_api/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'libpmempool_test.c',
 )

--- a/src/test/libpmempool_api_win/meson.build
+++ b/src/test/libpmempool_api_win/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'libpmempool_test_win.c',
 )

--- a/src/test/libpmempool_backup/meson.build
+++ b/src/test/libpmempool_backup/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/libpmempool_bttdev/meson.build
+++ b/src/test/libpmempool_bttdev/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/libpmempool_check_version/meson.build
+++ b/src/test/libpmempool_check_version/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'libpmempool_check_version.c',
 )

--- a/src/test/libpmempool_feature/meson.build
+++ b/src/test/libpmempool_feature/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'libpmempool_feature.c',
 )

--- a/src/test/libpmempool_include/meson.build
+++ b/src/test/libpmempool_include/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'libpmempool_include.c',
 )

--- a/src/test/libpmempool_map_flog/meson.build
+++ b/src/test/libpmempool_map_flog/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/libpmempool_rm/meson.build
+++ b/src/test/libpmempool_rm/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'libpmempool_rm.c',
 )

--- a/src/test/libpmempool_rm_remote/meson.build
+++ b/src/test/libpmempool_rm_remote/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/libpmempool_rm_win/meson.build
+++ b/src/test/libpmempool_rm_win/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'libpmempool_rm_win.c',
 )

--- a/src/test/libpmempool_sync/meson.build
+++ b/src/test/libpmempool_sync/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'libpmempool_sync.c',
 )

--- a/src/test/libpmempool_sync_win/meson.build
+++ b/src/test/libpmempool_sync_win/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'libpmempool_sync_win.c',
 )

--- a/src/test/libpmempool_transform/meson.build
+++ b/src/test/libpmempool_transform/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'libpmempool_transform.c',
 )

--- a/src/test/libpmempool_transform_win/meson.build
+++ b/src/test/libpmempool_transform_win/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'libpmempool_transform_win.c',
 )

--- a/src/test/log_basic/meson.build
+++ b/src/test/log_basic/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'log_basic.c',
 )

--- a/src/test/log_include/meson.build
+++ b/src/test/log_include/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'log_include.c',
 )

--- a/src/test/log_pool/meson.build
+++ b/src/test/log_pool/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'log_pool.c',
 )

--- a/src/test/log_pool_lock/meson.build
+++ b/src/test/log_pool_lock/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'log_pool_lock.c',
 )

--- a/src/test/log_pool_win/meson.build
+++ b/src/test/log_pool_win/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'log_pool_win.c',
 )

--- a/src/test/log_recovery/meson.build
+++ b/src/test/log_recovery/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'log_recovery.c',
 )

--- a/src/test/log_walker/meson.build
+++ b/src/test/log_walker/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'log_walker.c',
 )

--- a/src/test/magic/meson.build
+++ b/src/test/magic/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/meson.build
+++ b/src/test/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 tests = {
     'arch_flags': {},
     'blk_include': {},

--- a/src/test/mmap/meson.build
+++ b/src/test/mmap/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'mmap.c',
 )

--- a/src/test/mmap_fixed/meson.build
+++ b/src/test/mmap_fixed/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'mmap_fixed.c',
 )

--- a/src/test/obj_action/meson.build
+++ b/src/test/obj_action/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_action.c',
 )

--- a/src/test/obj_alloc/meson.build
+++ b/src/test/obj_alloc/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_alloc.c',
 )

--- a/src/test/obj_badblock/meson.build
+++ b/src/test/obj_badblock/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_badblock.c',
 )

--- a/src/test/obj_basic_integration/meson.build
+++ b/src/test/obj_basic_integration/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_basic_integration.c',
 )

--- a/src/test/obj_bucket/meson.build
+++ b/src/test/obj_bucket/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_bucket.c',
 )

--- a/src/test/obj_check/meson.build
+++ b/src/test/obj_check/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_check.c',
 )

--- a/src/test/obj_check_remote/meson.build
+++ b/src/test/obj_check_remote/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_check_remote.c',
 )

--- a/src/test/obj_constructor/meson.build
+++ b/src/test/obj_constructor/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_constructor.c',
 )

--- a/src/test/obj_critnib/meson.build
+++ b/src/test/obj_critnib/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_critnib.c',
 )

--- a/src/test/obj_critnib_mt/meson.build
+++ b/src/test/obj_critnib_mt/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_critnib_mt.c',
 )

--- a/src/test/obj_ctl_alignment/meson.build
+++ b/src/test/obj_ctl_alignment/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_ctl_alignment.c',
 )

--- a/src/test/obj_ctl_alloc_class/meson.build
+++ b/src/test/obj_ctl_alloc_class/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_ctl_alloc_class.c',
 )

--- a/src/test/obj_ctl_alloc_class_config/meson.build
+++ b/src/test/obj_ctl_alloc_class_config/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_ctl_alloc_class_config.c',
 )

--- a/src/test/obj_ctl_arenas/meson.build
+++ b/src/test/obj_ctl_arenas/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_ctl_arenas.c',
 )

--- a/src/test/obj_ctl_config/meson.build
+++ b/src/test/obj_ctl_config/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_ctl_config.c',
 )

--- a/src/test/obj_ctl_debug/meson.build
+++ b/src/test/obj_ctl_debug/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_ctl_debug.c',
 )

--- a/src/test/obj_ctl_heap_size/meson.build
+++ b/src/test/obj_ctl_heap_size/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_ctl_heap_size.c',
 )

--- a/src/test/obj_ctl_stats/meson.build
+++ b/src/test/obj_ctl_stats/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_ctl_stats.c',
 )

--- a/src/test/obj_debug/meson.build
+++ b/src/test/obj_debug/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_debug.c',
 )

--- a/src/test/obj_defrag/meson.build
+++ b/src/test/obj_defrag/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_defrag.c',
 )

--- a/src/test/obj_defrag_advanced/meson.build
+++ b/src/test/obj_defrag_advanced/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_defrag_advanced.c',
     'pgraph.c',

--- a/src/test/obj_direct/meson.build
+++ b/src/test/obj_direct/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_direct.c',
     'obj_direct_inline.c',

--- a/src/test/obj_direct_volatile/meson.build
+++ b/src/test/obj_direct_volatile/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_direct_volatile.c',
 )

--- a/src/test/obj_extend/meson.build
+++ b/src/test/obj_extend/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_extend.c',
 )

--- a/src/test/obj_first_next/meson.build
+++ b/src/test/obj_first_next/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_first_next.c',
 )

--- a/src/test/obj_fragmentation/meson.build
+++ b/src/test/obj_fragmentation/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_fragmentation.c',
 )

--- a/src/test/obj_fragmentation2/meson.build
+++ b/src/test/obj_fragmentation2/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_fragmentation2.c',
 )

--- a/src/test/obj_heap/meson.build
+++ b/src/test/obj_heap/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_heap.c',
 )

--- a/src/test/obj_heap_interrupt/meson.build
+++ b/src/test/obj_heap_interrupt/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_heap_interrupt.c',
 )

--- a/src/test/obj_heap_state/meson.build
+++ b/src/test/obj_heap_state/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_heap_state.c',
 )

--- a/src/test/obj_include/meson.build
+++ b/src/test/obj_include/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_atomic_base_include.c',
     'obj_atomic_include.c',

--- a/src/test/obj_lane/meson.build
+++ b/src/test/obj_lane/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_lane.c',
 )

--- a/src/test/obj_layout/meson.build
+++ b/src/test/obj_layout/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_layout.c',
 )

--- a/src/test/obj_list/meson.build
+++ b/src/test/obj_list/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_list_mocks_palloc.c',
     'obj_list_mocks.c',

--- a/src/test/obj_list_insert/meson.build
+++ b/src/test/obj_list_insert/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/obj_list_macro/meson.build
+++ b/src/test/obj_list_macro/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_list_macro.c',
 )

--- a/src/test/obj_list_move/meson.build
+++ b/src/test/obj_list_move/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/obj_list_recovery/meson.build
+++ b/src/test/obj_list_recovery/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/obj_list_remove/meson.build
+++ b/src/test/obj_list_remove/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/obj_list_valgrind/meson.build
+++ b/src/test/obj_list_valgrind/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/obj_locks/meson.build
+++ b/src/test/obj_locks/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_locks.c',
 )

--- a/src/test/obj_many_size_allocs/meson.build
+++ b/src/test/obj_many_size_allocs/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_many_size_allocs.c',
 )

--- a/src/test/obj_mem/meson.build
+++ b/src/test/obj_mem/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_mem.c',
 )

--- a/src/test/obj_memblock/meson.build
+++ b/src/test/obj_memblock/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_memblock.c',
 )

--- a/src/test/obj_memcheck/meson.build
+++ b/src/test/obj_memcheck/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_memcheck.c',
 )

--- a/src/test/obj_memcheck_register/meson.build
+++ b/src/test/obj_memcheck_register/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_memcheck_register.c',
 )

--- a/src/test/obj_memops/meson.build
+++ b/src/test/obj_memops/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_memops.c',
 )

--- a/src/test/obj_oid_thread/meson.build
+++ b/src/test/obj_oid_thread/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_oid_thread.c',
 )

--- a/src/test/obj_out_of_memory/meson.build
+++ b/src/test/obj_out_of_memory/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_out_of_memory.c',
 )

--- a/src/test/obj_persist_count/meson.build
+++ b/src/test/obj_persist_count/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_persist_count.c',
 )

--- a/src/test/obj_pmalloc_basic/meson.build
+++ b/src/test/obj_pmalloc_basic/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_pmalloc_basic.c',
 )

--- a/src/test/obj_pmalloc_mt/meson.build
+++ b/src/test/obj_pmalloc_mt/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_pmalloc_mt.c',
 )

--- a/src/test/obj_pmalloc_oom_mt/meson.build
+++ b/src/test/obj_pmalloc_oom_mt/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_pmalloc_oom_mt.c',
 )

--- a/src/test/obj_pmalloc_rand_mt/meson.build
+++ b/src/test/obj_pmalloc_rand_mt/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_pmalloc_rand_mt.c',
 )

--- a/src/test/obj_pmemcheck/meson.build
+++ b/src/test/obj_pmemcheck/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_pmemcheck.c',
 )

--- a/src/test/obj_pool/meson.build
+++ b/src/test/obj_pool/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_pool.c',
 )

--- a/src/test/obj_pool_lock/meson.build
+++ b/src/test/obj_pool_lock/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_pool_lock.c',
 )

--- a/src/test/obj_pool_lookup/meson.build
+++ b/src/test/obj_pool_lookup/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_pool_lookup.c',
 )

--- a/src/test/obj_pool_open_mt/meson.build
+++ b/src/test/obj_pool_open_mt/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_pool_open_mt.c',
 )

--- a/src/test/obj_pool_win/meson.build
+++ b/src/test/obj_pool_win/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_pool_win.c',
 )

--- a/src/test/obj_realloc/meson.build
+++ b/src/test/obj_realloc/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_realloc.c',
 )

--- a/src/test/obj_recovery/meson.build
+++ b/src/test/obj_recovery/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_recovery.c',
 )

--- a/src/test/obj_recreate/meson.build
+++ b/src/test/obj_recreate/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_recreate.c',
 )

--- a/src/test/obj_reorder_basic/meson.build
+++ b/src/test/obj_reorder_basic/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_reorder_basic.c',
 )

--- a/src/test/obj_root/meson.build
+++ b/src/test/obj_root/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_root.c',
 )

--- a/src/test/obj_rpmem_basic_integration/meson.build
+++ b/src/test/obj_rpmem_basic_integration/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/obj_rpmem_heap_interrupt/meson.build
+++ b/src/test/obj_rpmem_heap_interrupt/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/obj_rpmem_heap_state/meson.build
+++ b/src/test/obj_rpmem_heap_state/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/obj_sds/meson.build
+++ b/src/test/obj_sds/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_sds.c',
 )

--- a/src/test/obj_strdup/meson.build
+++ b/src/test/obj_strdup/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_strdup.c',
 )

--- a/src/test/obj_sync/meson.build
+++ b/src/test/obj_sync/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_sync.c',
     '../../libpmemobj/sync.c',

--- a/src/test/obj_toid/meson.build
+++ b/src/test/obj_toid/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_toid.c',
 )

--- a/src/test/obj_tx_add_range/meson.build
+++ b/src/test/obj_tx_add_range/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_tx_add_range.c',
 )

--- a/src/test/obj_tx_add_range_direct/meson.build
+++ b/src/test/obj_tx_add_range_direct/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_tx_add_range_direct.c',
 )

--- a/src/test/obj_tx_alloc/meson.build
+++ b/src/test/obj_tx_alloc/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_tx_alloc.c',
 )

--- a/src/test/obj_tx_callbacks/meson.build
+++ b/src/test/obj_tx_callbacks/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_tx_callbacks.c',
 )

--- a/src/test/obj_tx_flow/meson.build
+++ b/src/test/obj_tx_flow/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_tx_flow.c',
 )

--- a/src/test/obj_tx_free/meson.build
+++ b/src/test/obj_tx_free/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_tx_free.c',
 )

--- a/src/test/obj_tx_invalid/meson.build
+++ b/src/test/obj_tx_invalid/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_tx_invalid.c',
 )

--- a/src/test/obj_tx_lock/meson.build
+++ b/src/test/obj_tx_lock/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_tx_lock.c',
 )

--- a/src/test/obj_tx_locks/meson.build
+++ b/src/test/obj_tx_locks/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_tx_locks.c',
 )

--- a/src/test/obj_tx_locks_abort/meson.build
+++ b/src/test/obj_tx_locks_abort/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_tx_locks_abort.c',
 )

--- a/src/test/obj_tx_mt/meson.build
+++ b/src/test/obj_tx_mt/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_tx_mt.c',
 )

--- a/src/test/obj_tx_realloc/meson.build
+++ b/src/test/obj_tx_realloc/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_tx_realloc.c',
 )

--- a/src/test/obj_tx_strdup/meson.build
+++ b/src/test/obj_tx_strdup/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_tx_strdup.c',
 )

--- a/src/test/obj_tx_user_data/meson.build
+++ b/src/test/obj_tx_user_data/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_tx_user_data.c',
 )

--- a/src/test/obj_ulog_size/meson.build
+++ b/src/test/obj_ulog_size/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_ulog_size.c',
 )

--- a/src/test/obj_zones/meson.build
+++ b/src/test/obj_zones/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_zones.c',
 )

--- a/src/test/out_err/meson.build
+++ b/src/test/out_err/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'out_err.c',
 )

--- a/src/test/out_err_mt/meson.build
+++ b/src/test/out_err_mt/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'out_err_mt.c',
 )

--- a/src/test/out_err_mt_win/meson.build
+++ b/src/test/out_err_mt_win/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'out_err_mt_win.c',
 )

--- a/src/test/out_err_win/meson.build
+++ b/src/test/out_err_win/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'out_err_win.c',
 )

--- a/src/test/pmem2_api/meson.build
+++ b/src/test/pmem2_api/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_api.c',
 )

--- a/src/test/pmem2_badblock/meson.build
+++ b/src/test/pmem2_badblock/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_badblock.c',
 )

--- a/src/test/pmem2_badblock_mocks/meson.build
+++ b/src/test/pmem2_badblock_mocks/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_badblock_mocks.c',
     'mocks_ndctl.c',

--- a/src/test/pmem2_compat/meson.build
+++ b/src/test/pmem2_compat/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_compat.c',
 )

--- a/src/test/pmem2_config/meson.build
+++ b/src/test/pmem2_config/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_config.c',
 )

--- a/src/test/pmem2_deep_flush/meson.build
+++ b/src/test/pmem2_deep_flush/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_deep_flush.c',
     '../../libpmem2/deep_flush.c',

--- a/src/test/pmem2_future/meson.build
+++ b/src/test/pmem2_future/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_future.c',
 )

--- a/src/test/pmem2_granularity/meson.build
+++ b/src/test/pmem2_granularity/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_granularity.c',
 )

--- a/src/test/pmem2_granularity_detection/meson.build
+++ b/src/test/pmem2_granularity_detection/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/pmem2_include/meson.build
+++ b/src/test/pmem2_include/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_include.c',
 )

--- a/src/test/pmem2_integration/meson.build
+++ b/src/test/pmem2_integration/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_integration.c',
 )

--- a/src/test/pmem2_map/meson.build
+++ b/src/test/pmem2_map/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_map.c',
 )

--- a/src/test/pmem2_map_from_existing/meson.build
+++ b/src/test/pmem2_map_from_existing/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_map_from_existing.c',
 )

--- a/src/test/pmem2_map_prot/meson.build
+++ b/src/test/pmem2_map_prot/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_map_prot.c',
 )

--- a/src/test/pmem2_mem_ext/meson.build
+++ b/src/test/pmem2_mem_ext/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_mem_ext.c',
 )

--- a/src/test/pmem2_memcpy/meson.build
+++ b/src/test/pmem2_memcpy/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_memcpy.c',
     'memcpy_common.c',

--- a/src/test/pmem2_memmove/meson.build
+++ b/src/test/pmem2_memmove/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_memmove.c',
     'memmove_common.c',

--- a/src/test/pmem2_memset/meson.build
+++ b/src/test/pmem2_memset/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_memset.c',
     'memset_common.c'

--- a/src/test/pmem2_mover/meson.build
+++ b/src/test/pmem2_mover/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_mover.c',
 )

--- a/src/test/pmem2_movnt/meson.build
+++ b/src/test/pmem2_movnt/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_movnt.c',
 )

--- a/src/test/pmem2_movnt_align/meson.build
+++ b/src/test/pmem2_movnt_align/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_movnt_align.c',
     'movnt_align_common.c',

--- a/src/test/pmem2_perror/meson.build
+++ b/src/test/pmem2_perror/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_perror.c',
 )

--- a/src/test/pmem2_persist/meson.build
+++ b/src/test/pmem2_persist/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_persist.c',
 )

--- a/src/test/pmem2_persist_valgrind/meson.build
+++ b/src/test/pmem2_persist_valgrind/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_persist_valgrind.c',
 )

--- a/src/test/pmem2_source/meson.build
+++ b/src/test/pmem2_source/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_source.c',
 )

--- a/src/test/pmem2_source_alignment/meson.build
+++ b/src/test/pmem2_source_alignment/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_source_alignment.c',
 )

--- a/src/test/pmem2_source_numa/meson.build
+++ b/src/test/pmem2_source_numa/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_source_numa.c',
 )

--- a/src/test/pmem2_source_size/meson.build
+++ b/src/test/pmem2_source_size/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_source_size.c',
 )

--- a/src/test/pmem2_usc/meson.build
+++ b/src/test/pmem2_usc/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_usc.c',
 )

--- a/src/test/pmem2_vm_reservation/meson.build
+++ b/src/test/pmem2_vm_reservation/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem2_vm_reservation.c',
 )

--- a/src/test/pmem_deep_persist/meson.build
+++ b/src/test/pmem_deep_persist/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem_deep_persist.c',
     '../../libpmem/pmem.c',

--- a/src/test/pmem_eADR_functions/meson.build
+++ b/src/test/pmem_eADR_functions/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem_eADR_functions.c',
 )

--- a/src/test/pmem_has_auto_flush/meson.build
+++ b/src/test/pmem_has_auto_flush/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem_has_auto_flush.c',
 )

--- a/src/test/pmem_has_auto_flush_win/meson.build
+++ b/src/test/pmem_has_auto_flush_win/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem_has_auto_flush_win.c',
     'mocks_windows.c',

--- a/src/test/pmem_include/meson.build
+++ b/src/test/pmem_include/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem_include.c',
 )

--- a/src/test/pmem_is_pmem/meson.build
+++ b/src/test/pmem_is_pmem/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem_is_pmem.c',
 )

--- a/src/test/pmem_is_pmem_posix/meson.build
+++ b/src/test/pmem_is_pmem_posix/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem_is_pmem_posix.c',
 )

--- a/src/test/pmem_is_pmem_windows/meson.build
+++ b/src/test/pmem_is_pmem_windows/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem_is_pmem_windows.c',
 )

--- a/src/test/pmem_map_file/meson.build
+++ b/src/test/pmem_map_file/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem_map_file.c',
 )

--- a/src/test/pmem_map_file_trunc/meson.build
+++ b/src/test/pmem_map_file_trunc/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem_map_file_trunc.c',
 )

--- a/src/test/pmem_map_file_win/meson.build
+++ b/src/test/pmem_map_file_win/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem_map_file_win.c',
     'mocks_windows.c',

--- a/src/test/pmem_memcpy/meson.build
+++ b/src/test/pmem_memcpy/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem_memcpy.c',
     '../pmem2_memcpy/memcpy_common.c',

--- a/src/test/pmem_memmove/meson.build
+++ b/src/test/pmem_memmove/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem_memmove.c',
     '../pmem2_memmove/memmove_common.c',

--- a/src/test/pmem_memset/meson.build
+++ b/src/test/pmem_memset/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem_memset.c',
     '../pmem2_memset/memset_common.c',

--- a/src/test/pmem_movnt/meson.build
+++ b/src/test/pmem_movnt/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem_movnt.c',
 )

--- a/src/test/pmem_movnt_align/meson.build
+++ b/src/test/pmem_movnt_align/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem_movnt_align.c',
     '../pmem2_movnt_align/movnt_align_common.c',

--- a/src/test/pmem_unmap/meson.build
+++ b/src/test/pmem_unmap/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem_unmap.c',
 )

--- a/src/test/pmem_valgr_simple/meson.build
+++ b/src/test/pmem_valgr_simple/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmem_valgr_simple.c',
 )

--- a/src/test/pmemobjcli/meson.build
+++ b/src/test/pmemobjcli/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/pmempool_check/meson.build
+++ b/src/test/pmempool_check/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/pmempool_create/meson.build
+++ b/src/test/pmempool_create/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/pmempool_dump/meson.build
+++ b/src/test/pmempool_dump/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/pmempool_feature/meson.build
+++ b/src/test/pmempool_feature/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/pmempool_feature_remote/meson.build
+++ b/src/test/pmempool_feature_remote/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/pmempool_help/meson.build
+++ b/src/test/pmempool_help/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/pmempool_info/meson.build
+++ b/src/test/pmempool_info/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/pmempool_info_remote/meson.build
+++ b/src/test/pmempool_info_remote/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/pmempool_rm/meson.build
+++ b/src/test/pmempool_rm/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/pmempool_rm_remote/meson.build
+++ b/src/test/pmempool_rm_remote/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/pmempool_sync/meson.build
+++ b/src/test/pmempool_sync/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/pmempool_sync_remote/meson.build
+++ b/src/test/pmempool_sync_remote/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/pmempool_transform/meson.build
+++ b/src/test/pmempool_transform/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/pmempool_transform_remote/meson.build
+++ b/src/test/pmempool_transform_remote/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/pmemset_badblock/meson.build
+++ b/src/test/pmemset_badblock/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmemset_badblock.c',
 )

--- a/src/test/pmemset_config/meson.build
+++ b/src/test/pmemset_config/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmemset_config.c',
 )

--- a/src/test/pmemset_deep_flush/meson.build
+++ b/src/test/pmemset_deep_flush/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmemset_deep_flush.c',
 )

--- a/src/test/pmemset_event/meson.build
+++ b/src/test/pmemset_event/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmemset_event.c',
 )

--- a/src/test/pmemset_file/meson.build
+++ b/src/test/pmemset_file/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmemset_file.c',
 )

--- a/src/test/pmemset_include/meson.build
+++ b/src/test/pmemset_include/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmemset_include.c',
 )

--- a/src/test/pmemset_map_config/meson.build
+++ b/src/test/pmemset_map_config/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmemset_map_config.c',
 )

--- a/src/test/pmemset_memcpy/meson.build
+++ b/src/test/pmemset_memcpy/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmemset_memcpy.c',
     '../pmem2_memcpy/memcpy_common.c',

--- a/src/test/pmemset_memmove/meson.build
+++ b/src/test/pmemset_memmove/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmemset_memmove.c',
     '../pmem2_memmove/memmove_common.c',

--- a/src/test/pmemset_memset/meson.build
+++ b/src/test/pmemset_memset/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmemset_memset.c',
     '../pmem2_memset/memset_common.c',

--- a/src/test/pmemset_new/meson.build
+++ b/src/test/pmemset_new/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmemset_new.c',
 )

--- a/src/test/pmemset_part/meson.build
+++ b/src/test/pmemset_part/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmemset_part.c',
 )

--- a/src/test/pmemset_perror/meson.build
+++ b/src/test/pmemset_perror/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmemset_perror.c',
 )

--- a/src/test/pmemset_persist/meson.build
+++ b/src/test/pmemset_persist/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmemset_persist.c',
 )

--- a/src/test/pmemset_sds/meson.build
+++ b/src/test/pmemset_sds/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmemset_sds.c',
 )

--- a/src/test/pmemset_source/meson.build
+++ b/src/test/pmemset_source/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmemset_source.c',
 )

--- a/src/test/pmemspoil/meson.build
+++ b/src/test/pmemspoil/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/pmreorder_flushes/meson.build
+++ b/src/test/pmreorder_flushes/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmreorder_flushes.c',
 )

--- a/src/test/pmreorder_simple/meson.build
+++ b/src/test/pmreorder_simple/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmreorder_simple.c',
 )

--- a/src/test/pmreorder_stack/meson.build
+++ b/src/test/pmreorder_stack/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmreorder_stack.c',
 )

--- a/src/test/remote_basic/meson.build
+++ b/src/test/remote_basic/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'remote_basic.c',
 )

--- a/src/test/remote_obj_basic/meson.build
+++ b/src/test/remote_obj_basic/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'remote_obj_basic.c',
 )

--- a/src/test/rpmem_addr/meson.build
+++ b/src/test/rpmem_addr/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'rpmem_addr.c',
     '../../rpmem_common/rpmem_common.c',

--- a/src/test/rpmem_addr_ext/meson.build
+++ b/src/test/rpmem_addr_ext/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'rpmem_addr_ext.c',
 )

--- a/src/test/rpmem_basic/meson.build
+++ b/src/test/rpmem_basic/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'rpmem_basic.c',
     '../../rpmem_common/rpmem_common.c',

--- a/src/test/rpmem_fip/meson.build
+++ b/src/test/rpmem_fip/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'rpmem_fip_oob.c',
     'rpmem_fip_test.c',

--- a/src/test/rpmem_obc/meson.build
+++ b/src/test/rpmem_obc/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'rpmem_obc_test_close.c',
     'rpmem_obc_test_common.c',

--- a/src/test/rpmem_obc_int/meson.build
+++ b/src/test/rpmem_obc_int/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'rpmem_obc_int.c',
     '../../librpmem/rpmem_cmd.c',

--- a/src/test/rpmem_proto/meson.build
+++ b/src/test/rpmem_proto/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'rpmem_proto.c',
     '../../rpmem_common/rpmem_common.c',

--- a/src/test/rpmemd_config/meson.build
+++ b/src/test/rpmemd_config/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'rpmemd_config_test.c',
     '../../rpmem_common/rpmem_common.c',

--- a/src/test/rpmemd_db/meson.build
+++ b/src/test/rpmemd_db/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'rpmemd_db_test.c',
     '../../rpmem_common/rpmem_common.c',

--- a/src/test/rpmemd_dbg/meson.build
+++ b/src/test/rpmemd_dbg/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     '../rpmemd_db/rpmemd_db_test.c',
 )

--- a/src/test/rpmemd_log/meson.build
+++ b/src/test/rpmemd_log/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'rpmemd_log_test.c',
     '../../rpmem_common/rpmem_common.c',

--- a/src/test/rpmemd_obc/meson.build
+++ b/src/test/rpmemd_obc/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'rpmemd_obc_test_close.c',
     'rpmemd_obc_test_common.c',

--- a/src/test/rpmemd_util/meson.build
+++ b/src/test/rpmemd_util/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'rpmemd_util_test.c',
     '../../rpmem_common/rpmem_common.c',

--- a/src/test/scope/meson.build
+++ b/src/test/scope/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/set_funcs/meson.build
+++ b/src/test/set_funcs/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'set_funcs.c',
 )

--- a/src/test/signal_handle/meson.build
+++ b/src/test/signal_handle/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/traces/meson.build
+++ b/src/test/traces/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'traces.c',
 )

--- a/src/test/traces_custom_function/meson.build
+++ b/src/test/traces_custom_function/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'traces_custom_function.c',
 )

--- a/src/test/traces_pmem/meson.build
+++ b/src/test/traces_pmem/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'traces_pmem.c',
 )

--- a/src/test/unicode_api/meson.build
+++ b/src/test/unicode_api/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/unicode_match_script/meson.build
+++ b/src/test/unicode_match_script/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 copy_target = custom_target(t+'(test-files)',
     input : test_files,
     output :  test_files,

--- a/src/test/util_badblock/meson.build
+++ b/src/test/util_badblock/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'util_badblock.c',
 )

--- a/src/test/util_cpuid/meson.build
+++ b/src/test/util_cpuid/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'util_cpuid.c',
 )

--- a/src/test/util_ctl/meson.build
+++ b/src/test/util_ctl/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'util_ctl.c',
 )

--- a/src/test/util_extent/meson.build
+++ b/src/test/util_extent/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'util_extent.c',
 )

--- a/src/test/util_file_create/meson.build
+++ b/src/test/util_file_create/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'util_file_create.c',
 )

--- a/src/test/util_file_open/meson.build
+++ b/src/test/util_file_open/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'util_file_open.c',
 )

--- a/src/test/util_is_absolute/meson.build
+++ b/src/test/util_is_absolute/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'util_is_absolute.c',
 )

--- a/src/test/util_is_poolset/meson.build
+++ b/src/test/util_is_poolset/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'util_is_poolset.c',
 )

--- a/src/test/util_is_zeroed/meson.build
+++ b/src/test/util_is_zeroed/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'util_is_zeroed.c',
 )

--- a/src/test/util_map_proc/meson.build
+++ b/src/test/util_map_proc/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'util_map_proc.c',
 )

--- a/src/test/util_parse_size/meson.build
+++ b/src/test/util_parse_size/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'util_parse_size.c',
 )

--- a/src/test/util_pool_hdr/meson.build
+++ b/src/test/util_pool_hdr/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'util_pool_hdr.c',
 )

--- a/src/test/util_poolset/meson.build
+++ b/src/test/util_poolset/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'util_poolset.c',
 )

--- a/src/test/util_poolset_foreach/meson.build
+++ b/src/test/util_poolset_foreach/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'util_poolset_foreach.c',
 )

--- a/src/test/util_poolset_parse/meson.build
+++ b/src/test/util_poolset_parse/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'util_poolset_parse.c',
 )

--- a/src/test/util_poolset_size/meson.build
+++ b/src/test/util_poolset_size/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'util_poolset_size.c',
 )

--- a/src/test/util_ravl/meson.build
+++ b/src/test/util_ravl/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'util_ravl.c',
 )

--- a/src/test/util_sds/meson.build
+++ b/src/test/util_sds/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'util_sds.c',
 )

--- a/src/test/util_uuid_generate/meson.build
+++ b/src/test/util_uuid_generate/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'util_uuid_generate.c',
 )

--- a/src/test/util_vec/meson.build
+++ b/src/test/util_vec/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'util_vec.c',
 )

--- a/src/test/util_vecq/meson.build
+++ b/src/test/util_vecq/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'util_vecq.c',
 )

--- a/src/tools/meson.build
+++ b/src/tools/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 executable(
     'daxio',
     sources: files('daxio/daxio.c'),

--- a/testsuite/meson.build
+++ b/testsuite/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 subdir('tools')
 
 # Setup envconfig files

--- a/testsuite/tools/anonymous_mmap/meson.build
+++ b/testsuite/tools/anonymous_mmap/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'anonymous_mmap.c',
 )

--- a/testsuite/tools/bttcreate/meson.build
+++ b/testsuite/tools/bttcreate/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'bttcreate.c',
 )

--- a/testsuite/tools/cmpmap/meson.build
+++ b/testsuite/tools/cmpmap/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'cmpmap.c',
 )

--- a/testsuite/tools/cpufd/meson.build
+++ b/testsuite/tools/cpufd/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'cpufd.c',
     '../../../src/libpmem2/x86_64/cpu.c',

--- a/testsuite/tools/ctrld/meson.build
+++ b/testsuite/tools/ctrld/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'ctrld.c',
 )

--- a/testsuite/tools/ddmap/meson.build
+++ b/testsuite/tools/ddmap/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'ddmap.c',
 )

--- a/testsuite/tools/extents/meson.build
+++ b/testsuite/tools/extents/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'extents.c',
 )

--- a/testsuite/tools/fallocate_detect/meson.build
+++ b/testsuite/tools/fallocate_detect/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'fallocate_detect.c'
 )

--- a/testsuite/tools/gran_detecto/meson.build
+++ b/testsuite/tools/gran_detecto/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'gran_detecto.c',
 )

--- a/testsuite/tools/mapexec/meson.build
+++ b/testsuite/tools/mapexec/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'mapexec.c'
 )

--- a/testsuite/tools/meson.build
+++ b/testsuite/tools/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 ttools = {
     'anonymous_mmap': {},
     'bttcreate': {},

--- a/testsuite/tools/obj_verify/meson.build
+++ b/testsuite/tools/obj_verify/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'obj_verify.c'
 )

--- a/testsuite/tools/pmemalloc/meson.build
+++ b/testsuite/tools/pmemalloc/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmemalloc.c'
 )

--- a/testsuite/tools/pmemdetect/meson.build
+++ b/testsuite/tools/pmemdetect/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmemdetect.c',
 )

--- a/testsuite/tools/pmemobjcli/meson.build
+++ b/testsuite/tools/pmemobjcli/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'pmemobjcli.c'
 )

--- a/testsuite/tools/pmemspoil/meson.build
+++ b/testsuite/tools/pmemspoil/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'spoil.c',
 )

--- a/testsuite/tools/pmemwrite/meson.build
+++ b/testsuite/tools/pmemwrite/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'write.c'
 )

--- a/testsuite/tools/usc_permission_check/meson.build
+++ b/testsuite/tools/usc_permission_check/meson.build
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
 sources = files(
     'usc_permission_check.c',
 )

--- a/utils/check_license/check-headers.sh
+++ b/utils/check_license/check-headers.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2016-2020, Intel Corporation
+# Copyright 2016-2022, Intel Corporation
 
 # check-headers.sh - check copyright and license in source files
 
@@ -90,7 +90,8 @@ FILES=$($GIT $GIT_COMMAND | ${SOURCE_ROOT}/utils/check_license/file-exceptions.s
 	grep    -E -e '*\.[chs]$' -e '*\.[ch]pp$' -e '*\.sh$' \
 		   -e '*\.py$' -e '*\.link$' -e 'Makefile*' -e 'TEST*' \
 		   -e '/common.inc$' -e '/match$' -e '/check_whitespace$' \
-		   -e 'LICENSE$' -e 'CMakeLists.txt$' -e '*\.cmake$' | \
+		   -e 'LICENSE$' -e 'CMakeLists.txt$' -e '*\.cmake$' \
+		   -e 'meson.build$' | \
 	xargs)
 
 RV=0

--- a/utils/copy-file.py
+++ b/utils/copy-file.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+#
 
 import os, sys, shutil
 import argparse

--- a/utils/get-mocks.py
+++ b/utils/get-mocks.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2022, Intel Corporation
 #
+
 """
 Script parsing the 'FUNC_MOCK_RET_ALWAYS_VOID', 'FUNC_MOCK_RET_ALWAYS' and
 'FUNC_MOCK' macros from input source code files.

--- a/utils/list-files.py
+++ b/utils/list-files.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+#
+
 import os
 import re
 import sys

--- a/utils/write-file.py
+++ b/utils/write-file.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+#
 
 import os, sys
 


### PR DESCRIPTION
It's a small addition but there's a lot of files changed due to adding copyright license to all the meson.build files.